### PR TITLE
Add newline-mode for response

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 )
 
+var newLineTerm bool = false
+
 type result struct {
 	CpuNum       int   `json:"cpu_num"`
 	GoroutineNum int   `json:"goroutine_num"`
@@ -31,6 +33,14 @@ type result struct {
 	GcNext uint64 `json:"gc_next"`
 	GcLast uint64 `json:"gc_last"`
 	GcNum  uint32 `json:"gc_num"`
+}
+
+func NewLineTermEnabled() {
+	newLineTerm = true
+}
+
+func NewLineTermDisabled() {
+	newLineTerm = false
 }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
@@ -68,6 +78,10 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		body = jsonErr.Error()
 	} else {
 		body = string(jsonBytes)
+	}
+
+	if newLineTerm {
+		body += "\n"
 	}
 
 	headers := make(map[string]string)


### PR DESCRIPTION
This is a workaround for curl on cmdline-terminal.
When a response is not terminated with newline,
it is possible for a response not to output to cmdline-terminal.
